### PR TITLE
feat: add resumable download support

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
   catalogJsonFilePrev = "cache/catalog_prev.json"
   catalogJsonDiffFile = "cache/catalog_diff.json"
   updatedFlagFile     = "cache/updated"
+  progressFile        = "cache/progress.json"
 )
 
 func doAnalyze() {
@@ -96,6 +97,7 @@ func main() {
   fClientVersion := flag.String("client-version", "", "Specify client version manually.")
   fResInfo := flag.String("res-info", "", "Specify resource info manually.")
   fFilterRegex := flag.String("filter-regex", "", "Only download assets that match the regex pattern. eg. --filter-regex=\"bgm_.*\"")
+  fFlushInterval := flag.Int("flush-interval", 50, "Number of files processed before saving progress to disk.")
   flag.Parse()
 
   if *fAnalyze {
@@ -121,7 +123,7 @@ func main() {
     }
     
     // Only decrypt existing assets
-    manifest.DecryptAllAssets(catalog, decrpytedAssetsSaveDir, assetsSaveDir)
+    manifest.DecryptAllAssets(catalog, decrpytedAssetsSaveDir, assetsSaveDir, nil, "")
     
     rich.Info("Conversion completed.")
     return
@@ -208,7 +210,8 @@ func main() {
     }
   }
 
-  if !*fForce && resInfo == string(currentVer) {
+  progress := manifest.LoadProgress(progressFile)
+  if !*fForce && resInfo == string(currentVer) && progress == nil {
     rich.Info("Nothing updated, will be stopping process.")
     return
   }
@@ -259,7 +262,7 @@ func main() {
     Entries: oldEntries,
   }
 
-  if !*fForce {
+  if !*fForce && progress == nil {
     diff(catalog, oldCatalog)
   }
 
@@ -276,11 +279,19 @@ func main() {
     return
   }
 
+  if progress != nil && progress.ResInfo == resInfo {
+    rich.Info("Resuming from previous progress.")
+  } else {
+    progress = manifest.NewProgress(resInfo, catalog, *fFlushInterval)
+    progress.Save(progressFile)
+    rich.Info("Created new progress file.")
+  }
+
   // download all assets
-  network.DownloadAssetsAsync(catalog, assetsSaveDir, fKeepPath)
+  network.DownloadAssetsAsync(catalog, assetsSaveDir, fKeepPath, progress, progressFile)
 
   // decrypt all assets
-  manifest.DecryptAllAssets(catalog, decrpytedAssetsSaveDir, assetsSaveDir)
+  manifest.DecryptAllAssets(catalog, decrpytedAssetsSaveDir, assetsSaveDir, progress, progressFile)
 
   // convert db files to yaml
   if err := os.MkdirAll(dbSaveDir, 0755); err != nil {
@@ -310,6 +321,9 @@ func main() {
     }
     // marshal catalog to a yaml file
     utils.WriteToYamlFile(rows, dbSaveDir+"/"+reflect.TypeOf(ins).Name()+".yaml")
+  }
+  if !progress.Cleanup(progressFile) {
+    rich.Error("Some assets failed to process, please check the log, you can re-run the program to continue.")
   }
   cvf, err := os.Create(catalogVersionFile)
   if err != nil {

--- a/manifest/asset.go
+++ b/manifest/asset.go
@@ -35,7 +35,7 @@ type Asset struct {
   // Md5           [16]byte
 }
 
-func DecryptAllAssets(catalog *Catalog, dstDir string, srcDir string) {
+func DecryptAllAssets(catalog *Catalog, dstDir string, srcDir string, progress *Progress, progressPath string) {
   counter := 0
   amount := len(catalog.Entries)
 
@@ -45,6 +45,12 @@ func DecryptAllAssets(catalog *Catalog, dstDir string, srcDir string) {
   }
   for _, entry := range catalog.Entries {
     counter++
+    if progress != nil {
+      status := progress.GetStatus(entry.RealName)
+      if status == StatusDecrypted || status == StatusFailed {
+          continue
+      }
+    }
     var suffix = ""
     if entry.ResourceType == 1 {
       suffix = ".assetbundle"
@@ -100,6 +106,9 @@ func DecryptAllAssets(catalog *Catalog, dstDir string, srcDir string) {
       DecodeAsset(asset, plainBuf, rawBuf)
     }
     plainBuf.Flush()
+    if progress != nil {
+      progress.UpdateStatus(entry.RealName, StatusDecrypted, progressPath)
+    }
     rich.Info("(%d/%d) Asset file %q(%v) was successfully processed.", counter, amount, entry.StrLabelCrc, entry.RealName)
     rawFile.Close()
     plainFile.Close()

--- a/manifest/progress.go
+++ b/manifest/progress.go
@@ -1,0 +1,117 @@
+package manifest
+
+import (
+  "encoding/json"
+  "os"
+  "sync"
+  "vertesan/hailstorm/rich"
+)
+
+type DownloadStatus string
+
+const (
+  StatusPending DownloadStatus = "pending"
+  StatusFailed DownloadStatus = "failed"
+  StatusDownloaded DownloadStatus = "downloaded"
+  StatusDecrypted DownloadStatus = "decrypted"
+)
+
+type ProgressEntry struct {
+  RealName string `json:"real_name"`
+  Label    string `json:"label"`
+  Status   DownloadStatus `json:"status"`
+}
+
+type Progress struct {
+  ResInfo string `json:"res_info"`
+  Entries map[string]ProgressEntry `json:"entries"`
+  mu sync.Mutex
+  dirty int
+  FlushInterval int `json:"flush_interval"`
+}
+
+func LoadProgress(file string) *Progress {
+  if _, err := os.Stat(file); os.IsNotExist(err) {
+    return nil
+  }
+  data, err := os.ReadFile(file)
+  if err != nil {
+    rich.Panic("failed to read progress file: %v", err)
+  }
+  var progress Progress
+  err = json.Unmarshal(data, &progress)
+  if err != nil {
+    rich.Panic("failed to unmarshal progress file: %v", err)
+  }
+  return &progress
+}
+
+func NewProgress(resInfo string, catalog *Catalog, flushInterval int) *Progress {
+  entries := make(map[string]ProgressEntry, len(catalog.Entries))
+  for _, e := range catalog.Entries {
+    entries[e.RealName] = ProgressEntry{
+      RealName: e.RealName,
+      Label: e.StrLabelCrc,
+      Status: StatusPending,
+    }
+  }
+  if flushInterval <= 0 {
+    flushInterval = 50
+  }
+  return &Progress{
+    ResInfo: resInfo,
+    Entries: entries,
+    FlushInterval: flushInterval,
+  }
+}
+
+func (p *Progress) saveLocked(path string) {
+  data, err := json.MarshalIndent(p, "", "  ")
+  if err != nil {
+    rich.Panic("failed to marshal progress file: %v", err)
+  }
+  if err := os.WriteFile(path, data, 0644); err != nil {
+    rich.Panic("failed to write progress file: %v", err)
+  }
+}
+
+func (p *Progress) Save(path string) {
+  p.mu.Lock()
+  defer p.mu.Unlock()
+  p.saveLocked(path)
+}
+
+func (p *Progress) GetStatus(realName string) DownloadStatus {
+  p.mu.Lock()
+  defer p.mu.Unlock()
+  if entry, ok := p.Entries[realName]; ok {
+    return entry.Status
+  }
+  return StatusPending
+}
+
+func (p *Progress) UpdateStatus(realName string, status DownloadStatus, path string) {
+  p.mu.Lock()
+  defer p.mu.Unlock()
+  entry := p.Entries[realName]
+  entry.Status = status
+  p.Entries[realName] = entry
+  p.dirty++
+  if p.dirty >= p.FlushInterval {
+    p.dirty = 0
+    p.saveLocked(path)
+  }
+}
+
+func (p *Progress) Cleanup(path string) bool {
+  p.mu.Lock()
+  defer p.mu.Unlock()
+  for _, entry := range p.Entries {
+    if entry.Status == StatusFailed {
+      p.saveLocked(path)
+      return false
+    }
+  }
+  os.Remove(path)
+  return true
+}

--- a/network/downloader.go
+++ b/network/downloader.go
@@ -3,6 +3,7 @@ package network
 import (
   "bufio"
   "context"
+  "errors"
   "fmt"
   "net/http"
   "os"
@@ -67,11 +68,13 @@ func DownloadManifestSync(realName string, saveDir string) {
   if err := os.MkdirAll(saveDir, 0755); err != nil {
     panic(err)
   }
-  downloadOne(entry, saveDir, assetHeader, nil, counter, 1)
+  if err := downloadOne(entry, saveDir, assetHeader, nil, counter, 1, nil, ""); err != nil {
+    rich.Panic("Manifest download failed, due to %s", err)
+  }
   rich.Info("Manifest is successfully downloaded.")
 }
 
-func DownloadAssetsAsync(catalog *manifest.Catalog, downloadDir string, keepPath *bool) {
+func DownloadAssetsAsync(catalog *manifest.Catalog, downloadDir string, keepPath *bool, progress *manifest.Progress, progressPath string) {
   sem := semaphore.NewWeighted(MAX_CONCURRENCY)
   dlAmount := len(catalog.Entries)
   counter := &SafeCounter{}
@@ -86,6 +89,14 @@ func DownloadAssetsAsync(catalog *manifest.Catalog, downloadDir string, keepPath
     //   rich.Info("(%d/%d) File %q already exists, skip downloading.", counter.Value(), dlAmount, entry.RealName)
     //   continue
     // }
+    if progress != nil {
+      status := progress.GetStatus(entry.RealName)
+      if status == manifest.StatusDownloaded || status == manifest.StatusDecrypted {
+        counter.Increase()
+        rich.Info("(%d/%d) Skipping already downloaded: %q.", counter.Value(), dlAmount, entry.StrLabelCrc)
+        continue
+      }
+    }
     saveToDir := downloadDir
     if *keepPath {
       var resType string
@@ -102,7 +113,7 @@ func DownloadAssetsAsync(catalog *manifest.Catalog, downloadDir string, keepPath
     if err := sem.Acquire(ctx, 1); err != nil {
       panic(err)
     }
-    go downloadOne(&entry, saveToDir, assetHeader, sem, counter, dlAmount)
+    go downloadOne(&entry, saveToDir, assetHeader, sem, counter, dlAmount, progress, progressPath)
   }
 
   // wait all concurrencies completed
@@ -119,7 +130,9 @@ func downloadOne(
   sem *semaphore.Weighted,
   counter *SafeCounter,
   amount int,
-) {
+  progress *manifest.Progress,
+  progressPath string,
+) error {
   if sem != nil {
     defer sem.Release(1)
   }
@@ -168,12 +181,19 @@ func downloadOne(
     }
 
     counter.Increase()
+    if progress != nil {
+      progress.UpdateStatus(entry.RealName, manifest.StatusDownloaded, progressPath)
+    }
     rich.Info("(%d/%d) Download completed: %q(%v).", counter.Value(), amount, entry.StrLabelCrc, entry.RealName)
     res.Body.Close()
-    return
+    return nil
   }
   // max retry exhausted
-  rich.Panic("Max retries exhausted when downloading %v. Will be stopping process.", request.URL)
+  rich.Error("Max retries exhausted when downloading %v. Will be stopping process.", request.URL)
+  if progress != nil {
+    progress.UpdateStatus(entry.RealName, manifest.StatusFailed, progressPath)
+  }
+  return errors.New("max retries exhausted")
 }
 
 func prepareRequest(entry *manifest.Entry, header http.Header) *http.Request {


### PR DESCRIPTION
## Issue
When a download is interrupted, the next run incorrectly skips the incomplete version due to catalog diff.

## Changes
- Track download/decrypt status via progress.json
- Skip already completed assets on restart
- Batch flush progress to disk for performance